### PR TITLE
Added sed call to normalise line endings on OWA Post data

### DIFF
--- a/spray.sh
+++ b/spray.sh
@@ -170,7 +170,7 @@ if [ "$1" == "-owa" ] || [ "$1" == "--owa" ] || [ "$1" == "owa" ] ; then
     touch logs/spray-logs.txt
     
     # convert line endings on POST data; required if you C&P from Burp.
-    sed -i.bak "/\r\n/\n/g" $postrequest
+    sed -i.bak "s/\r\n/\n/g" $postrequest
 
     #Initial spray for same username as password
     time=$(date +%H:%M:%S)

--- a/spray.sh
+++ b/spray.sh
@@ -170,7 +170,7 @@ if [ "$1" == "-owa" ] || [ "$1" == "--owa" ] || [ "$1" == "owa" ] ; then
     touch logs/spray-logs.txt
     
     # convert line endings on POST data; required if you C&P from Burp.
-    sed -i.bak "s/\r\n/\n/g" $postrequest
+    sed -i.bak 's/.$//' $postrequest
 
     #Initial spray for same username as password
     time=$(date +%H:%M:%S)

--- a/spray.sh
+++ b/spray.sh
@@ -168,6 +168,9 @@ if [ "$1" == "-owa" ] || [ "$1" == "--owa" ] || [ "$1" == "owa" ] ; then
     postrequest=$7
     counter=0
     touch logs/spray-logs.txt
+    
+    # convert line endings on POST data; required if you C&P from Burp.
+    sed -i.bak "/\r\n/\n/g" $postrequest
 
     #Initial spray for same username as password
     time=$(date +%H:%M:%S)


### PR DESCRIPTION
I encountered an issue where I copied the POST request from Burp into a text file, and Windows line-endings were included, causing the grep for the POST data to fail.
Running dos2unix resolved this, so I added a 'sed' call to normalise the line endings in all cases.